### PR TITLE
Add LICENSE to the files which are included in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["text-processing", "internationalization"]
 homepage = "https://lib.rs/crates/deunicode"
 repository = "https://github.com/kornelski/deunicode/"
 readme = "README.md"
-include = ["src/*", "Cargo.toml", "README.md"]
+include = ["src/*", "Cargo.toml", "README.md", "LICENSE"]
 edition = "2021"
 
 keywords = [


### PR DESCRIPTION
Most licenses require that redistributed sources contain a copy of the license terms - this includes the BSD-3-Clause license. Hence, adding the LICENSE file to crates that are published and redistributed via crates.io, and possibly re-redistributed by Linux distributions, is necessary.

c.f. https://github.com/kornelski/deunicode/issues/3#issuecomment-498004908

Fixes #3 